### PR TITLE
Backend refactor: central db util and env config

### DIFF
--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -1,7 +1,6 @@
+PORT=5000
 DB_HOST=localhost
-DB_PORT=5432
-DB_USER=myuser
-DB_PASS=mypassword
-DB_NAME=mydb
-DB_PROVIDER=postgresql
-PORT=3001
+DB_PORT=1433
+DB_USER=sa
+DB_PASS=yourStrong(!)Password
+DB_NAME=master

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -1,0 +1,21 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const PORT = parseInt(process.env.PORT || '5000', 10);
+
+export interface DbConfig {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+}
+
+export const defaultDbConfig: DbConfig = {
+  host: process.env.DB_HOST || 'localhost',
+  port: parseInt(process.env.DB_PORT || '1433', 10),
+  user: process.env.DB_USER || '',
+  password: process.env.DB_PASS || '',
+  database: process.env.DB_NAME || '',
+};

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,13 +1,17 @@
 import express from 'express';
-import tablesRoute from './routes/tables'; // ✅ NOT .ts — just the route path
+import morgan from 'morgan';
+import tablesRoute from './routes/tables';
 import exportRoute from './routes/export';
+import connectRoute from './routes/connect';
+import { PORT } from './config';
 
 const app = express();
-const PORT = 5000;
 
+app.use(morgan('dev'));
 app.use(express.json());
 
 // ✅ Correct way to mount routers
+app.use('/api/connect', connectRoute);
 app.use('/api/tables', tablesRoute);
 app.use('/api/export', exportRoute);
 

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "fastify": "^5.3.3",
+        "morgan": "^1.10.0",
         "mssql": "^10.0.1",
         "openapi3-ts": "^4.4.0",
         "prisma": "^6.9.0",
@@ -23,7 +24,9 @@
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
+        "@types/morgan": "^1.9.10",
         "@types/mssql": "^9.1.7",
+        "@types/node": "^20.11.25",
         "@types/ssh2-sftp-client": "^9.0.4",
         "@types/swagger-ui-express": "^4.1.8",
         "nodemon": "^3.1.10",
@@ -696,6 +699,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/morgan": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
+      "integrity": "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mssql": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/@types/mssql/-/mssql-9.1.7.tgz",
@@ -709,9 +722,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
-      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "version": "20.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
+      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1059,6 +1072,24 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/bcrypt-pbkdf": {
@@ -3026,6 +3057,49 @@
         "node": "*"
       }
     },
+    "node_modules/morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/morgan/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3186,6 +3260,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -18,6 +18,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "fastify": "^5.3.3",
+    "morgan": "^1.10.0",
     "mssql": "^10.0.1",
     "openapi3-ts": "^4.4.0",
     "prisma": "^6.9.0",
@@ -27,7 +28,9 @@
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
+    "@types/morgan": "^1.9.10",
     "@types/mssql": "^9.1.7",
+    "@types/node": "^20.11.25",
     "@types/ssh2-sftp-client": "^9.0.4",
     "@types/swagger-ui-express": "^4.1.8",
     "nodemon": "^3.1.10",

--- a/src/backend/routes/connect.ts
+++ b/src/backend/routes/connect.ts
@@ -1,25 +1,15 @@
 import { Router, Request, Response } from 'express';
-import mssql from 'mssql';
+import { withDb } from '../utils/db';
+import { DbConfig } from '../config';
 
 const router = Router();
 
 router.post('/', async (req: Request, res: Response) => {
   const { user, password, host, port, database } = req.body;
+  const dbConfig: DbConfig = { host, port: parseInt(port, 10), user, password, database };
 
   try {
-    const pool = await mssql.connect({
-      user,
-      password,
-      server: host,
-      port: parseInt(port, 10),
-      database,
-      options: {
-        encrypt: false,
-        trustServerCertificate: true
-      }
-    });
-
-    await pool.close();
+    await withDb(dbConfig, async () => {});
     res.json({ success: true, message: 'Connected successfully!' });
   } catch (err: any) {
     res.status(500).json({ success: false, message: err.message });

--- a/src/backend/routes/tables.ts
+++ b/src/backend/routes/tables.ts
@@ -1,35 +1,22 @@
 import { Router, Request, Response } from 'express';
-import mssql from 'mssql';
+import { withDb } from '../utils/db';
+import { DbConfig } from '../config';
 
 const router = Router();
 
 router.post('/', async (req: Request, res: Response) => {
   const { user, password, host, port, database } = req.body;
-
+  const dbConfig: DbConfig = { host, port: parseInt(port, 10), user, password, database };
   try {
-    const pool = await mssql.connect({
-      user,
-      password,
-      server: host,
-      port: parseInt(port, 10),
-      database,
-      options: {
-        encrypt: false,
-        trustServerCertificate: true
-      }
+    const tableNames = await withDb(dbConfig, async pool => {
+      const result = await pool.request().query(`
+        SELECT TABLE_NAME
+        FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_TYPE = 'BASE TABLE'
+      `);
+      return result.recordset.map(row => row.TABLE_NAME);
     });
-
-    const result = await pool.request().query(`
-      SELECT TABLE_NAME
-      FROM INFORMATION_SCHEMA.TABLES
-      WHERE TABLE_TYPE = 'BASE TABLE'
-    `);
-
-    await pool.close();
-
-    const tableNames = result.recordset.map(row => row.TABLE_NAME);
     res.json({ tables: tableNames });
-
   } catch (err: any) {
     console.error('[TABLES ERROR]', err);
     res.status(500).json({ error: err.message });

--- a/src/backend/utils/db.ts
+++ b/src/backend/utils/db.ts
@@ -1,0 +1,18 @@
+import mssql from 'mssql';
+import { DbConfig } from '../config';
+
+export async function withDb<T>(config: DbConfig, fn: (pool: mssql.ConnectionPool) => Promise<T>): Promise<T> {
+  const pool = await mssql.connect({
+    user: config.user,
+    password: config.password,
+    server: config.host,
+    port: config.port,
+    database: config.database,
+    options: { encrypt: false, trustServerCertificate: true },
+  });
+  try {
+    return await fn(pool);
+  } finally {
+    await pool.close();
+  }
+}

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:3001
+VITE_API_URL=http://localhost:5000


### PR DESCRIPTION
## Summary
- add typed environment loader and DB connection util
- refactor routes to reuse DB helper
- hook up `/api/connect` route
- add request logging via morgan
- provide example env files for frontend and backend

## Testing
- `npm run build` in `src/backend`
- `npm run build` in `src/frontend`

------
https://chatgpt.com/codex/tasks/task_e_6847ae24c120832fbfb7a58643cae421